### PR TITLE
Compsognathus bodysize fix

### DIFF
--- a/1.5/Defs/ThingDef_Races/Race_Compsognathus.xml
+++ b/1.5/Defs/ThingDef_Races/Race_Compsognathus.xml
@@ -67,11 +67,11 @@ A tiny bipedal carnivore that primarily eats insects and fish, yet has been obse
     <race>
       <body>QuadrupedAnimalWithPawsAndTail</body>
       <baseHungerRate>0.5</baseHungerRate>
-      <baseBodySize>1.5</baseBodySize>
+      <baseBodySize>0.5</baseBodySize>
       <baseHealthScale>2.0</baseHealthScale>
       <packAnimal>false</packAnimal>
       <predator>true</predator>
-      <maxPreyBodySize>0.8</maxPreyBodySize>
+      <maxPreyBodySize>0.5</maxPreyBodySize>
       <foodType>CarnivoreAnimal</foodType>
       <leatherDef>Leather_SmallDino</leatherDef>
       <useMeatFrom>JRWAcrocanthosaurus</useMeatFrom>


### PR DESCRIPTION
The body size of Compsognathus is currently set to '1.5'. Compare that to the human body size of '1.0' and realize that this would make them quite a bit larger than the average human. But in real life Compsognathus was one of the smallest dinosaurs, standing at most little over 3 feet tall. They are also portrayed this way in the Jurassic Park movies. 

I've set the body size to 0.5 now; which should more accurately reflect their size in both reality and the movies. I've also updated their MaxPreyBodySize so they won't hunt things that could now chomp them in half with ease.